### PR TITLE
Another workaround for messy teardown environment

### DIFF
--- a/src/testing/postgresql.py
+++ b/src/testing/postgresql.py
@@ -113,7 +113,8 @@ class Postgresql(Database):
 
     def terminate(self, *args):
         # send SIGINT instead of SIGTERM
-        super(Postgresql, self).terminate(signal.SIGINT)
+        if Postgresql:
+            super(Postgresql, self).terminate(signal.SIGINT)
 
 
 class PostgresqlFactory(DatabaseFactory):


### PR DESCRIPTION
Similar to https://github.com/tk0miya/testing.common.database/pull/1 -- during teardown of my py.test cases the actual `Postgresql` module might already have been cleaned up, in which case sending a termination signal fails.