### PR TITLE
Fix to support Windows

### DIFF
--- a/src/testing/postgresql.py
+++ b/src/testing/postgresql.py
@@ -113,7 +113,7 @@ class Postgresql(Database):
 
     def terminate(self, *args):
         # send SIGINT instead of SIGTERM
-        super(Postgresql, self).terminate(signal.SIGINT)
+        super(Postgresql, self).terminate(signal.SIGINT if os.name != 'nt' else None)
 
 
 class PostgresqlFactory(DatabaseFactory):

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -116,6 +116,7 @@ class TestPostgresql(unittest.TestCase):
             testing.postgresql.SEARCH_PATHS = search_paths
             os.environ['PATH'] = path_env
 
+    @unittest.skipIf(os.name == 'nt', 'Windows does not have fork()')
     def test_fork(self):
         pgsql = testing.postgresql.Postgresql()
         if os.fork() == 0:
@@ -127,6 +128,7 @@ class TestPostgresql(unittest.TestCase):
             sleep(1)
             self.assertTrue(pgsql.is_alive())  # process is alive (delete pgsql obj in child does not effect)
 
+    @unittest.skipIf(os.name == 'nt', 'Windows does not have fork()')
     def test_stop_on_child_process(self):
         pgsql = testing.postgresql.Postgresql()
         if os.fork() == 0:

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,16 @@
 [tox]
 envlist=py26,py27,py32,py33,py34,py35
 
-[testenv]
+[base]
 deps=
     nose
-    flake8
     psycopg2
     SQLAlchemy
+
+[testenv]
+deps=
+    {[base]deps}
+    flake8
 passenv=
     TRAVIS*
 commands=
@@ -15,8 +19,9 @@ commands=
 
 [testenv:py26]
 deps=
-    {[testenv]deps}
+    {[base]deps}
     unittest2
+    flake8==2.6.0
 
 [testenv:coverage]
 deps=


### PR DESCRIPTION
I'm using the tool on Windows and receiving the error as documented in #16
The following pull request seems to fix the issue with the invalid signal.
- Assumes all other platforms work with sigint instead of sigterm
- testcases with os.fork are skipped on Windows
