### PR TITLE
Pin pg8000 to version <= 1.12.4 on Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,12 @@ classifiers = [
     "Topic :: Software Development :: Testing",
 ]
 
-install_requires = ['testing.common.database >= 1.1.0', 'pg8000 >= 1.10']
+install_requires = ['testing.common.database >= 1.1.0']
 if sys.version_info < (2, 7):
     install_requires.append('unittest2')
+    install_requires.append('pg8000 >= 1.10, <= 1.12.4')
+else:
+    install_requires.append('pg8000 >= 1.10')
 
 
 setup(


### PR DESCRIPTION
Because pg8000 Version 1.13.0, released on 2019-02-01, drops support for Python 2.

Fixes #28