### PR TITLE
Replace assertRegexpMatches() with assertRegex()

### DIFF
--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -28,7 +28,7 @@ class TestPostgresql(unittest.TestCase):
             # connect to postgresql (w/ psycopg2)
             conn = psycopg2.connect(**pgsql.dsn())
             self.assertIsNotNone(conn)
-            self.assertRegexpMatches(pgsql.read_bootlog(), 'is ready to accept connections')
+            self.assertRegex(pgsql.read_bootlog(), 'is ready to accept connections')
             conn.close()
 
             # connect to postgresql (w/ sqlalchemy)
@@ -38,7 +38,7 @@ class TestPostgresql(unittest.TestCase):
             # connect to postgresql (w/ pg8000)
             conn = pg8000.connect(**pgsql.dsn())
             self.assertIsNotNone(conn)
-            self.assertRegexpMatches(pgsql.read_bootlog(), 'is ready to accept connections')
+            self.assertRegex(pgsql.read_bootlog(), 'is ready to accept connections')
             conn.close()
         finally:
             # shutting down


### PR DESCRIPTION
This alias was deprecated in Python 3.2 and is removed in Python 3.12.

Reference: https://docs.python.org/3.12/whatsnew/3.12.html